### PR TITLE
feat: support `image_input` for image embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ You may use `/run` (asynchronous, start job and return job ID) or `/runsync` (sy
 Inputs:
 * `model`: name of one of the deployed models.
 * `input`: single text string or list of texts to embed
+* `image_input`: single url or list of urls to embed (for use with CLIP models)
 
 ### Reranking
 Inputs:

--- a/src/embedding_service.py
+++ b/src/embedding_service.py
@@ -89,7 +89,7 @@ class EmbeddingService:
         if not isinstance(image_input, list):
             image_input = [image_input]
 
-        embeddings, usage = await self.engine_array[model_name].embed_image(image_input)
+        embeddings, usage = await self.engine_array[model_name].image_embed(image_input)
         if return_as_list:
             return [
                 list_embeddings_to_response(embeddings, model=model_name, usage=usage)

--- a/src/embedding_service.py
+++ b/src/embedding_service.py
@@ -57,6 +57,7 @@ class EmbeddingService:
     async def route_openai_get_embeddings(
         self,
         embedding_input: str | list[str],
+        image_input: str | list[str],
         model_name: str,
         return_as_list: bool = False,
     ):
@@ -67,6 +68,28 @@ class EmbeddingService:
             embedding_input = [embedding_input]
 
         embeddings, usage = await self.engine_array[model_name].embed(embedding_input)
+        if return_as_list:
+            return [
+                list_embeddings_to_response(embeddings, model=model_name, usage=usage)
+            ]
+        else:
+            return list_embeddings_to_response(
+                embeddings, model=model_name, usage=usage
+            )
+
+    async def route_get_image_embeddings(
+        self,
+        image_input: str | list[str],
+        model_name: str,
+        return_as_list: bool = False,
+    ):
+        """returns embeddings for the input image urls"""
+        if not self.is_running:
+            await self.start()
+        if not isinstance(image_input, list):
+            image_input = [image_input]
+
+        embeddings, usage = await self.engine_array[model_name].embed_image(image_input)
         if return_as_list:
             return [
                 list_embeddings_to_response(embeddings, model=model_name, usage=usage)

--- a/src/embedding_service.py
+++ b/src/embedding_service.py
@@ -57,7 +57,6 @@ class EmbeddingService:
     async def route_openai_get_embeddings(
         self,
         embedding_input: str | list[str],
-        image_input: str | list[str],
         model_name: str,
         return_as_list: bool = False,
     ):

--- a/src/handler.py
+++ b/src/handler.py
@@ -47,6 +47,12 @@ async def async_generator_handler(job: dict[str, Any]):
                 "embedding_input": job_input.get("input"),
                 "model_name": job_input.get("model"),
             }
+        # handle image urls (for image embeddings)
+        elif job_input.get("image_input"):
+            call_fn, kwargs = embedding_service.route_get_image_embeddings, {
+                "image_input": job_input.get("image_input"),
+                "model_name": job_input.get("model"),
+            }
         else:
             return create_error_response(f"Invalid input: {job}").model_dump()
     try:


### PR DESCRIPTION
adds a new route that is called when `image_input` is provided that will call `image_embed` for use with CLIP models.